### PR TITLE
[codex] Tighten repo AGENTS guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,14 +8,14 @@ This file is for coding agents working in this repo.
 - Keep the site structure intentionally small: homepage, blog index, and blog post detail pages.
 - Prefer extending the current content-driven approach in `src/Content.elm` instead of reintroducing starter/demo routes.
 
-## Content rules
+## Content
 
 - Support mixed frontmatter formats already present in `content/`.
 - Derive blog slugs from filenames, not titles.
 - Do not publish drafts by accident. Draft posts should stay out of the blog index and generated public routes unless the user explicitly asks otherwise.
 - Missing optional metadata or missing referenced images should degrade gracefully.
 
-## Useful files
+## Key files
 
 - `src/Content.elm`: content loading, normalization, markdown rendering, draft filtering
 - `app/Route/Index.elm`: homepage
@@ -25,15 +25,9 @@ This file is for coding agents working in this repo.
 
 ## Verification
 
-- Use `npm start` for local dev.
-- Use `npm run format` before review/build for Elm edits.
-- Use `npm run review` as the lint/review step.
-- Use `npm run build` for production verification.
-- Use `npm run deploy` for the documented GitHub Pages publish flow.
+- `npm start`: local dev
+- `npm run format`: format Elm edits before review/build
+- `npm run review`: lint/review step
+- `npm run build`: production verification
+- `npm run deploy`: documented GitHub Pages publish flow
 - If Lamdera reports dependency/cache issues, document the exact command and failure rather than papering over it.
-
-## Recommended Review Tools
-
-- `npm run review`: repo-level static review via `elm-review`
-- `npm run format`: formatting and low-noise diffs for Elm changes
-- `rg`: fast text search for finding stale references, route wiring, and content usage


### PR DESCRIPTION
## Summary
- trim the repo AGENTS.md down to project-specific guidance
- remove duplicated workflow and tool guidance that already belongs in user-level AGENTS or skills
- keep the repo content, routing, and verification conventions intact

## Why
The repo AGENTS.md should stay concise and repository-specific. This change removes generic guidance that overlaps with user-level defaults and skills while preserving the conventions that are actually specific to this site.

## Validation
- reviewed the repo AGENTS.md against ~/.codex/AGENTS.md
- checked relevant user-level skills for overlapping guidance
- confirmed the repo diff only changes AGENTS.md
